### PR TITLE
Update builders.type to work with Packer >= 0.5

### DIFF
--- a/nixbox-template.json.orig
+++ b/nixbox-template.json.orig
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_wait": "1m",
       "boot_command": [
         "root<enter>",

--- a/nixbox32-template.json
+++ b/nixbox32-template.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_wait": "1m",
       "boot_command": [
         "root<enter>",

--- a/nixbox64-template.json
+++ b/nixbox64-template.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_wait": "1m",
       "boot_command": [
         "root<enter>",


### PR DESCRIPTION
`virtualbox` builder has been renamed to `virtualbox-iso`.
