### PR TITLE
Update README.md to fix Vagrant box names in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ packer build --only=hyperv-iso nixos-x86_64.json
 The vagrant .box image is now ready to go and you can use it in vagrant:
 
 ```
-vagrant box add nixbox32 packer_virtualbox-iso_virtualbox.box
+vagrant box add nixbox32 nixos-21.05-virtualbox-i686.box
 # or
-vagrant box add nixbox64 packer_virtualbox-iso_virtualbox.box
+vagrant box add nixbox64 nixos-21.05-virtualbox-x86_64.box
 ```
 
 Updating the ISO urls


### PR DESCRIPTION
Minor update to the README to use the same Vagrant box naming format as the Packer JSON.

Comes from the box outputs here:
* i686 - https://github.com/nix-community/nixbox/blob/97c04c470f59b00738915f9da915b0e4f165c7e0/nixos-i686.json#L136
* x86_64 - https://github.com/nix-community/nixbox/blob/97c04c470f59b00738915f9da915b0e4f165c7e0/nixos-x86_64.json#L136